### PR TITLE
Fix Telegram gateway image path handling

### DIFF
--- a/plugins/telegram_gateway.py
+++ b/plugins/telegram_gateway.py
@@ -27,6 +27,7 @@ options shown match the docs pattern; pick whichever matches your build.
 import asyncio
 import logging
 import threading
+import os
 from dataclasses import dataclass, field
 from typing import Optional, AsyncIterator
 
@@ -318,6 +319,9 @@ class Plugin(BasePlugin):
                 for img_path in images:
                     sent_any = True
                     try:
+                        img_path = self.window.core.filesystem.to_workdir(img_path)
+                        if not os.path.exists(img_path):
+                            raise FileNotFoundError(f"Missing image: {img_path}")
                         with open(img_path, "rb") as fh:
                             await context.bot.send_photo(chat_id=chat_id, photo=fh)
                     except Exception:


### PR DESCRIPTION
## Summary
- ensure Telegram gateway resolves `%workdir%` placeholders before sending images
- add filesystem lookup and existence check for image paths

## Testing
- `pytest` *(fails: ModuleNotFoundError and other missing dependency errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899b7fe32c48326a2625f5f3b0ea9b3