### PR TITLE
Initialize telegram gateway metadata

### DIFF
--- a/plugins/telegram_gateway.py
+++ b/plugins/telegram_gateway.py
@@ -81,13 +81,12 @@ class MainThreadInvoker(QObject):
 class Plugin(BasePlugin):
     """Telegram gateway plugin"""
 
-    id = "telegram_gateway"
-    name = "Telegram Gateway"
-    version = "1.0.0"
-    description = "Receive text from Telegram and reply using PyGPT."
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.id = "telegram_gateway"
+        self.name = "Telegram Gateway"
+        self.version = "1.0.0"
+        self.description = "Receive text from Telegram and reply using PyGPT."
         self.state = _BotState()  # runtime TG state
         self.allowed_users = set()  # optional allowlist by Telegram user id
         self._invoker = MainThreadInvoker(parent=self.window)


### PR DESCRIPTION
## Summary
- Initialize Telegram Gateway plugin metadata inside `__init__`

## Testing
- `pytest tests/plugin/agent/test_plugin_agent.py -q`
- `QT_QPA_PLATFORM=offscreen timeout 5 python run.py` *(fails: ModuleNotFoundError: No module named 'llama_index')*

------
https://chatgpt.com/codex/tasks/task_e_6899c205200c83269fbda3a367511dba