### PR TITLE
Handle extra sub reply context in Telegram gateway

### DIFF
--- a/plugins/telegram_gateway.py
+++ b/plugins/telegram_gateway.py
@@ -400,7 +400,13 @@ class Plugin(BasePlugin):
             if (
                 last_ctx is not None
                 and last_ctx is not curr_ctx
-                and getattr(last_ctx, "sub_reply", False)
+                and (
+                    getattr(last_ctx, "sub_reply", False)
+                    or (
+                        isinstance(getattr(last_ctx, "extra", None), dict)
+                        and last_ctx.extra.get("sub_reply")
+                    )
+                )
             ):
                 curr_ctx = last_ctx
                 prev_output = None


### PR DESCRIPTION
## Summary
- broaden context switching to check `ctx.extra['sub_reply']`
- reset telegram gateway streaming trackers when switching context
- add tests for sub replies flagged via extra field

## Testing
- `pytest tests/plugin/telegram_gateway/test_telegram_gateway.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899ccf1053c8326b5b68823d496ba8c