### PR TITLE
Handle empty responses in Telegram gateway

### DIFF
--- a/plugins/telegram_gateway.py
+++ b/plugins/telegram_gateway.py
@@ -315,8 +315,11 @@ class Plugin(BasePlugin):
                         disable_web_page_preview=True,
                     )
                 for reply_text in texts:
+                    cleaned = reply_text.strip()
+                    if not cleaned:
+                        continue
                     sent_any = True
-                    reply_text = escape_markdown(reply_text or "(no response)", version=2)
+                    reply_text = escape_markdown(cleaned, version=2)
                     await context.bot.send_message(
                         chat_id=chat_id,
                         text=reply_text,


### PR DESCRIPTION
## Summary
- skip empty or whitespace-only text chunks in Telegram replies
- test Telegram gateway for empty outputs and final fallback

## Testing
- `pytest tests/plugin/telegram_gateway/test_telegram_gateway.py -q`
- `pytest -q` *(fails: ImportError: libxkbcommon.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689a8f8b4e588326b8774bf33296c045