### PR TITLE
Add Telegram help command

### DIFF
--- a/plugins/telegram_gateway.py
+++ b/plugins/telegram_gateway.py
@@ -282,6 +282,7 @@ class Plugin(BasePlugin):
         app.add_handler(CommandHandler("mode", self._on_mode))
         app.add_handler(CommandHandler("plugin", self._on_plugin))
         app.add_handler(CommandHandler("model", self._on_model))
+        app.add_handler(CommandHandler("help", self._on_help))
         app.add_handler(CommandHandler("agent", self._on_agent))
 
         # Optionally, you can add a /start or /help command handler
@@ -457,6 +458,38 @@ class Plugin(BasePlugin):
             )
         except Exception as e:
             reply_text = escape_markdown(f"⚠️ Error: {e}", version=2)
+
+        await context.bot.send_message(
+            chat_id=chat_id,
+            text=reply_text,
+            parse_mode=ParseMode.MARKDOWN_V2,
+            disable_web_page_preview=True,
+        )
+
+    async def _on_help(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if not update.effective_chat or not update.effective_user:
+            return
+
+        chat_id = update.effective_chat.id
+        user_id = update.effective_user.id
+
+        if self.allowed_users and user_id not in self.allowed_users:
+            await context.bot.send_message(
+                chat_id=chat_id,
+                text="This bot is locked. Your Telegram user ID is not allowed.",
+            )
+            return
+
+        commands = (
+            "Supported commands:\n"
+            "/new - start new context\n"
+            "/mode <name> - switch mode\n"
+            "/plugin <enable|disable> <plugin_id> - manage plugins\n"
+            "/model <name> - switch model\n"
+            "/agent <id> - switch agent\n"
+            "/help - show this message"
+        )
+        reply_text = escape_markdown(commands, version=2)
 
         await context.bot.send_message(
             chat_id=chat_id,


### PR DESCRIPTION
## Summary
- expose a `/help` command in the Telegram gateway
- document supported commands for users
- test help handler formatting

## Testing
- `pytest tests/plugin/telegram_gateway/test_telegram_gateway.py::test_on_help_lists_commands -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'llama_index', 'sqlalchemy', 'pydub', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689aa66646cc83268e4a535c72969d06