### PR TITLE
Handle agent output contexts in Telegram gateway

### DIFF
--- a/tests/plugin/telegram_gateway/test_telegram_gateway.py
+++ b/tests/plugin/telegram_gateway/test_telegram_gateway.py
@@ -129,6 +129,43 @@ def test_ask_pygpt_monitors_extra_sub_reply(mock_window):
     assert images == ["img.png"]
 
 
+def test_ask_pygpt_monitors_agent_output(mock_window):
+    with patch("plugins.telegram_gateway.MainThreadInvoker", DummyInvoker):
+        plugin = Plugin(window=mock_window)
+
+    initial = CtxItem()
+    initial.output = None
+    initial.results = []
+    initial.images = []
+
+    agent = CtxItem()
+    agent.agent_output = True
+    agent.output = "here"
+    agent.results = []
+    agent.images = ["img.png"]
+
+    plugin._text_send_on_main = MagicMock(return_value=initial)
+
+    call = {"n": 0}
+
+    def get_last_item():
+        call["n"] += 1
+        return agent if call["n"] > 1 else initial
+
+    mock_window.core.ctx.get_last_item = get_last_item
+
+    async def run():
+        with patch("plugins.telegram_gateway.asyncio.sleep", new=AsyncMock()):
+            agen = plugin._ask_pygpt("test")
+            texts, images = await asyncio.wait_for(anext(agen), timeout=1)
+            await agen.aclose()
+            return texts, images
+
+    texts, images = asyncio.run(run())
+    assert texts == ["here"]
+    assert images == ["img.png"]
+
+
 @patch("plugins.telegram_gateway.os.path.exists", return_value=True)
 @patch("plugins.telegram_gateway.open", new_callable=mock_open, read_data=b"data")
 def test_on_text_forwards_tool_reply(mock_open_fn, mock_exists, mock_window):


### PR DESCRIPTION
## Summary
- switch to contexts flagged as `agent_output` and reset streaming state
- stop streaming when `agent_finish` appears
- document and test agent mode support

## Testing
- `pytest tests/plugin/telegram_gateway/test_telegram_gateway.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab6d8861883269a39bc8847622edb