### PR TITLE
Use kernel state for telegram gateway streaming

### DIFF
--- a/plugins/telegram_gateway.py
+++ b/plugins/telegram_gateway.py
@@ -779,7 +779,8 @@ class Plugin(BasePlugin):
 
         loop = asyncio.get_running_loop()
         deadline = loop.time() + 120.0  # seconds
-        idle_window = 60.0
+        idle_window = 3.0
+        kernel = self.window.controller.kernel
 
         last_seen = loop.time()
         got_any = False
@@ -839,6 +840,10 @@ class Plugin(BasePlugin):
                 last_seen = loop.time()
                 got_any = True
                 yield new_texts, new_images
+
+            if got_any and kernel.state != kernel.STATE_BUSY:
+                log.info("[TelegramGateway] Kernel not busy; finishing")
+                break
 
             if got_any and (loop.time() - last_seen) > idle_window:
                 log.info("[TelegramGateway] Idle window expired; finishing")

--- a/tests/plugin/telegram_gateway/test_telegram_gateway.py
+++ b/tests/plugin/telegram_gateway/test_telegram_gateway.py
@@ -44,6 +44,9 @@ def mock_window():
     window.core.config.get_lang = MagicMock(return_value='en')
     window.core.debug = MagicMock()
     window.controller = MagicMock()
+    window.controller.kernel = MagicMock()
+    window.controller.kernel.STATE_BUSY = 'busy'
+    window.controller.kernel.state = 'idle'
     window.tools = MagicMock()
     window.ui = MagicMock()
     window.threadpool = MagicMock()


### PR DESCRIPTION
## Summary
- monitor kernel state in `_ask_pygpt` to end streaming when no longer busy
- reduce idle timeout to 3s as fallback
- adjust telegram gateway tests to mock kernel controller

## Testing
- `pytest tests/plugin/telegram_gateway/test_telegram_gateway.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab78abe248326a6aa89f9572b3b7f