### PR TITLE
refactor: add config for telegram gateway plugin

### DIFF
--- a/src/pygpt_net/plugin/telegram_gateway/config.py
+++ b/src/pygpt_net/plugin/telegram_gateway/config.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ================================================== #
+# This file is a part of PYGPT package               #
+# Website: https://pygpt.net                         #
+# GitHub:  https://github.com/szczyglis-dev/py-gpt   #
+# MIT License                                        #
+# Created By  : Marcin Szczygliński                  #
+# Updated Date: 2025.02.16 00:00:00                  #
+# ================================================== #
+
+from pygpt_net.plugin.base.config import BaseConfig, BasePlugin
+
+
+class Config(BaseConfig):
+    def __init__(self, plugin: BasePlugin = None, *args, **kwargs):
+        super(Config, self).__init__(plugin)
+        self.plugin = plugin
+
+    def from_defaults(self, plugin: BasePlugin = None):
+        """Set default options for plugin"""
+        plugin.add_option(
+            "bot_token",
+            type="text",
+            value="",
+            label="Telegram Bot Token",
+            description="Create a bot with @BotFather and paste the token here.",
+            secret=True,
+        )
+        plugin.add_option(
+            "allowed_user_ids",
+            type="text",
+            value="",
+            label="Allowed Telegram User IDs (comma-separated, optional)",
+            description="Leave blank to allow anyone who knows the bot username.",
+        )

--- a/src/pygpt_net/plugin/telegram_gateway/plugin.py
+++ b/src/pygpt_net/plugin/telegram_gateway/plugin.py
@@ -59,6 +59,8 @@ from telegram.helpers import escape_markdown
 from telegram.error import TimedOut
 from PySide6.QtCore import QTimer, QObject, Signal
 
+from .config import Config
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
@@ -103,20 +105,12 @@ class Plugin(BasePlugin):
         self.state = _BotState()  # runtime TG state
         self.allowed_users = set()  # optional allowlist by Telegram user id
         self._invoker = MainThreadInvoker(parent=self.window)
-        # plugin options
-        self.add_option(
-            "bot_token",
-            type="text",
-            label="Telegram Bot Token",
-            description="Create a bot with @BotFather and paste the token here.",
-            secret=True,
-        )
-        self.add_option(
-            "allowed_user_ids",
-            type="text",
-            label="Allowed Telegram User IDs (comma-separated, optional)",
-            description="Leave blank to allow anyone who knows the bot username.",
-        )
+        self.config = Config(self)
+        self.init_options()
+
+    def init_options(self):
+        """Initialize options"""
+        self.config.from_defaults(self)
 
     # ---------- PyGPT lifecycle ----------
 


### PR DESCRIPTION
## Summary
- refactor telegram gateway plugin to use Config subclass for options
- move plugin options into dedicated config.py and load via init_options

## Testing
- `pytest` *(fails: 180 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b1881620c8326932b27532a7e2241